### PR TITLE
Optimize tokenizer

### DIFF
--- a/super-tiny-compiler-unannotated.js
+++ b/super-tiny-compiler-unannotated.js
@@ -1,6 +1,9 @@
 function tokenizer(input) {
   var current = 0;
   var tokens = [];
+  var WHITESPACE = /\s/;
+  var NUMBERS = /[0-9]/;
+  var LETTERS = /[a-zA-Z]/;
 
   while (current < input.length) {
     var char = input[current];
@@ -23,13 +26,11 @@ function tokenizer(input) {
       continue;
     }
 
-    var WHITESPACE = /\s/;
     if (WHITESPACE.test(char)) {
       current++;
       continue;
     }
 
-    var NUMBERS = /[0-9]/;
     if (NUMBERS.test(char)) {
       var value = '';
 
@@ -46,7 +47,6 @@ function tokenizer(input) {
       continue;
     }
 
-    var LETTERS = /[a-zA-Z]/;
     if (LETTERS.test(char)) {
       var value = '';
 

--- a/super-tiny-compiler.js
+++ b/super-tiny-compiler.js
@@ -348,6 +348,11 @@ function tokenizer(input) {
   // And a `tokens` array for pushing our tokens to.
   var tokens = [];
 
+  // Regex tests for later
+  var WHITESPACE = /\s/;
+  var NUMBERS = /[0-9]/;
+  var LETTERS = /[a-zA-Z]/;
+
   // We start by creating a `while` loop where we are setting up our `current`
   // variable to be incremented as much as we want `inside` the loop.
   //
@@ -398,7 +403,6 @@ function tokenizer(input) {
     //
     // So here we're just going to test for existence and if it does exist we're
     // going to just `continue` on.
-    var WHITESPACE = /\s/;
     if (WHITESPACE.test(char)) {
       current++;
       continue;
@@ -413,7 +417,6 @@ function tokenizer(input) {
     //        Only two separate tokens
     //
     // So we start this off when we encounter the first number in a sequence.
-    var NUMBERS = /[0-9]/;
     if (NUMBERS.test(char)) {
 
       // We're going to create a `value` string that we are going to push
@@ -446,7 +449,6 @@ function tokenizer(input) {
     //    ^^^
     //    Name token
     //
-    var LETTERS = /[a-zA-Z]/;
     if (LETTERS.test(char)) {
       var value = '';
 


### PR DESCRIPTION
Re-declaring the regex every loop can slow things down a lot.
If you move them outside the while loop, you don't have to waste cycles on garbage collecting the variables, or creating new ones.