### PR TITLE
missed square bracket in new AST

### DIFF
--- a/super-tiny-compiler.js
+++ b/super-tiny-compiler.js
@@ -751,7 +751,7 @@ function traverser(ast, visitor) {
  *                                    |             type: 'NumberLiteral',
  *                                    |             value: '2'
  *                                    |           }]
- *  (sorry the other one is longer.)  |         }
+ *  (sorry the other one is longer.)  |         }]
  *                                    |       }
  *                                    |     }]
  *                                    |   }


### PR DESCRIPTION
3 arrays are opened in new ast but only 2 are closed. 
In test.js, it is correctly closed.