### PR TITLE
Added support for underscore and alphanumeric in type name

### DIFF
--- a/super-tiny-compiler.js
+++ b/super-tiny-compiler.js
@@ -446,13 +446,15 @@ function tokenizer(input) {
     //    ^^^
     //    Name token
     //
-    var LETTERS = /[a-zA-Z_0-9]/;
-    if (LETTERS.test(char)) {
+    var validIdentifierStart = /[a-zA-Z_]/;
+    var validIdentifierChar = /[a-zA-Z_0-9]/;
+    if (validIdentifierStart.test(char)) {
+    	
       var value = '';
 
       // Again we're just going to loop through all the letters pushing them to
       // a value.
-      while (LETTERS.test(char)) {
+      while (validIdentifierChar.test(char)) {
         value += char;
         char = input[++current];
       }
@@ -465,7 +467,7 @@ function tokenizer(input) {
 
       continue;
     }
-
+    
     // Finally if we have not matched a character by now, we're going to throw
     // an error and completely exit.
     throw new TypeError('I dont know what this character is: ' + char);

--- a/test.js
+++ b/test.js
@@ -81,4 +81,10 @@ assert.deepStrictEqual(transformer(ast), newAst, 'Transformer should turn `ast` 
 assert.deepStrictEqual(codeGenerator(newAst), output, 'Code Generator should turn `newAst` into `output` string');
 assert.deepStrictEqual(compiler(input), output, 'Compiler should turn `input` into `output`');
 
+//Identifier Test
+input = '(_add 2 (subtract 4 2))';
+output = '_add(2, subtract(4, 2));';
+assert.deepStrictEqual(compiler(input), output, 'Compiler should turn `input` into `output`');
 console.log('All Passed!');
+
+


### PR DESCRIPTION
The tokenizer was initially handling only letters. Now it can handle all valid C identifiers including names beginning with underscores and alphanumeric names. 
It will not handle names beginning with a number as it is not a valid C identifier.
Example:
input1 = '(_add 2 (subtract 4 2))';

