### PR TITLE
Add Missing "Not"

### DIFF
--- a/the-super-tiny-compiler.js
+++ b/the-super-tiny-compiler.js
@@ -259,7 +259,7 @@
  *
  * If we were manipulating this AST directly, instead of creating a separate AST,
  * we would likely introduce all sorts of abstractions here. But just visiting
- * each node in the tree is enough.
+ * each node in the tree is not enough.
  *
  * The reason I use the word "visiting" is because there is this pattern of how
  * to represent operations on elements of an object structure.


### PR DESCRIPTION
The way the sentence reads seems to imply the word "not" has been accidentally omitted.

If my correction is incorrect, I suggest that the sentence be adjusted to say, "Visiting each node in the tree is enough".