### PR TITLE
change interface for visitor in description

### DIFF
--- a/the-super-tiny-compiler.js
+++ b/the-super-tiny-compiler.js
@@ -709,16 +709,31 @@ function parser(tokens) {
  * encounter a node with a matching type.
  *
  *   traverse(ast, {
- *     Program(node, parent) {
- *       // ...
+ *     Program: {
+ *       enter(node, parent) {
+ *         // ...
+ *       },
+ *       exit(node, parent) {
+ *         // ...
+ *       },
  *     },
  *
- *     CallExpression(node, parent) {
- *       // ...
+ *     CallExpression: {
+ *       enter(node, parent) {
+ *         // ...
+ *       },
+ *       exit(node, parent) {
+ *         // ...
+ *       },
  *     },
  *
- *     NumberLiteral(node, parent) {
- *       // ...
+ *     NumberLiteral: {
+ *       enter(node, parent) {
+ *         // ...
+ *       },
+ *       exit(node, parent) {
+ *         // ...
+ *       },
  *     },
  *   });
  */


### PR DESCRIPTION
The "final form of our visitor" was introduced earlier, so it can be confusing to use a different interface at this point, because it doesn't match the real implementation.