### PR TITLE
Different infinite loop

### DIFF
--- a/the-super-tiny-compiler.js
+++ b/the-super-tiny-compiler.js
@@ -378,8 +378,9 @@
 
 // We start by accepting an input string of code, and we're gonna set up two
 // things...
-function tokenizer(input) {
+function tokenizer(p_input) {
 
+  let input = p_input + ' ';
   // A `current` variable for tracking our position in the code like a cursor.
   let current = 0;
 

--- a/the-super-tiny-compiler.js
+++ b/the-super-tiny-compiler.js
@@ -380,7 +380,8 @@
 // things...
 function tokenizer(p_input) {
 
-  let input = p_input + ' ';
+  //Fixes an infinite loop where the file ends before certain while loops end.
+  let input = p_input + ' '; 
   // A `current` variable for tracking our position in the code like a cursor.
   let current = 0;
 


### PR DESCRIPTION
There is actually another infinite loop in the code. When testing, I found that this would hang.:
`console.log(lexer("add"));`
This is caused by the while loop for names assuming that there is always a character following text. This patch fixes this by adding a space to the end of the lexer input, which is used to cause these while loops to exit.
