### PR TITLE
fix: fix `dont` to `dont't`

### DIFF
--- a/the-super-tiny-compiler.js
+++ b/the-super-tiny-compiler.js
@@ -530,7 +530,7 @@ function tokenizer(input) {
 
     // Finally if we have not matched a character by now, we're going to throw
     // an error and completely exit.
-    throw new TypeError('I dont know what this character is: ' + char);
+    throw new TypeError('I don\'t know what this character is: ' + char);
   }
 
   // Then at the end of our `tokenizer` we simply return the tokens array.


### PR DESCRIPTION
I'm translating the-super-tiny-compiler using rust, and found this typo. I just couldn't resist :) .