### PR TITLE
Update to use ES Modules

### DIFF
--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import {
   transformer,
   codeGenerator,
   compiler,
-} from './the-super-tiny-compiler.ja';
+} from './the-super-tiny-compiler.js';
 import assert from 'assert/strict';
 
 const input  = '(add 2 (subtract 4 2))';

--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
-const {
+import {
   tokenizer,
   parser,
   transformer,
   codeGenerator,
   compiler,
-} = require('./the-super-tiny-compiler');
-const assert = require('assert');
+} from './the-super-tiny-compiler.ja';
+import assert from 'assert/strict';
 
 const input  = '(add 2 (subtract 4 2))';
 const output = 'add(2, subtract(4, 2));';

--- a/the-super-tiny-compiler.js
+++ b/the-super-tiny-compiler.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * TTTTTTTTTTTTTTTTTTTTTTTHHHHHHHHH     HHHHHHHHHEEEEEEEEEEEEEEEEEEEEEE
  * T:::::::::::::::::::::TH:::::::H     H:::::::HE::::::::::::::::::::E
@@ -1043,7 +1041,7 @@ function compiler(input) {
  */
 
 // Now I'm just exporting everything...
-module.exports = {
+export {
   tokenizer,
   parser,
   traverser,


### PR DESCRIPTION
Updates code to use modern `import` / `export` syntax, as well as removing `'use-strict'` as strict mode is enabled automatically for ES Modules.